### PR TITLE
emacsclient: check WAYLAND_DISPLAY

### DIFF
--- a/lib-src/emacsclient.c
+++ b/lib-src/emacsclient.c
@@ -611,7 +611,9 @@ decode_options (int argc, char **argv)
       alt_display = "w32";
 #endif
 
-      display = egetenv ("DISPLAY");
+      display = egetenv ("WAYLAND_DISPLAY");
+      if (!display)
+	display = egetenv ("DISPLAY");
     }
 
   if (!display)


### PR DESCRIPTION
This avoids `emacsclient -c` falling back to xwayland or terminal.