### PR TITLE
PGTK double-buffer Optimisations 

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -34,10 +34,6 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <c-ctype.h>
 #include <flexmember.h>
 
-#ifdef HAVE_PGTK
-#include <cairo.h>
-#endif
-
 #include "lisp.h"
 #include "frame.h"
 #include "process.h"
@@ -406,7 +402,8 @@ static cairo_pattern_t *
 image_create_pattern_from_pixbuf (struct frame *f, GdkPixbuf *pixbuf)
 {
   GdkPixbuf *pb = gdk_pixbuf_add_alpha (pixbuf, TRUE, 255, 255, 255);
-  cairo_surface_t *surface = cairo_surface_create_similar_image (f->output_data.pgtk->cr_surface,
+  cairo_surface_t *surface = cairo_surface_create_similar_image (cairo_get_target(
+								   f->output_data.pgtk->cr_context),
 								 CAIRO_FORMAT_A1,
 								 gdk_pixbuf_get_width (pb),
 								 gdk_pixbuf_get_height (pb));

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -486,7 +486,6 @@ pgtk_iconify_frame (struct frame *f)
   SET_FRAME_ICONIFIED (f, true);
   SET_FRAME_VISIBLE (f, 0);
 
-  gdk_flush();
   unblock_input ();
 }
 
@@ -521,8 +520,6 @@ pgtk_make_frame_visible (struct frame *f)
       gtk_widget_show(win);
       gtk_window_deiconify(GTK_WINDOW(win));
 
-      gdk_flush();
-
       if (FLOATP (Vpgtk_wait_for_event_timeout)) {
 	guint msec = (guint) (XFLOAT_DATA (Vpgtk_wait_for_event_timeout) * 1000);
 	int found = 0;
@@ -550,7 +547,6 @@ pgtk_make_frame_invisible (struct frame *f)
   GtkWidget *win = FRAME_OUTPUT_DATA(f)->widget;
 
   gtk_widget_hide(win);
-  gdk_flush();
 
   SET_FRAME_VISIBLE (f, 0);
   SET_FRAME_ICONIFIED (f, false);
@@ -3284,9 +3280,6 @@ pgtk_hide_hourglass(struct frame *f)
 static void
 pgtk_flush_display (struct frame *f)
 {
-  block_input ();
-  gdk_flush();
-  unblock_input ();
 }
 
 extern frame_parm_handler pgtk_frame_parm_handlers[];

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -61,8 +61,9 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 
 #define STORE_KEYSYM_FOR_DEBUG(keysym) ((void)0)
 
-#define FRAME_CR_CONTEXT(f)	((f)->output_data.pgtk->cr_context)
-#define FRAME_CR_SURFACE(f)	((f)->output_data.pgtk->cr_surface)
+#define FRAME_CR_CONTEXT(f) ((f)->output_data.pgtk->cr_context)
+#define FRAME_CR_ACTIVE_CONTEXT(f)	((f)->output_data.pgtk->cr_active)
+#define FRAME_CR_SURFACE(f) (cairo_get_target(FRAME_CR_CONTEXT(f)))
 #define FRAME_CR_SURFACE_DESIRED_WIDTH(f)		\
   ((f)->output_data.pgtk->cr_surface_desired_width)
 #define FRAME_CR_SURFACE_DESIRED_HEIGHT(f) \
@@ -94,6 +95,22 @@ static void pgtk_clip_to_row (struct window *w, struct glyph_row *row,
 				enum glyph_row_area area, cairo_t *cr);
 static struct frame *
 pgtk_any_window_to_frame (GdkWindow *window);
+
+static void flip_cr_context(struct frame *f)
+{
+  APGTK_TRACE("flip_cr_context");
+  cairo_t * cr = FRAME_CR_ACTIVE_CONTEXT(f);
+
+  block_input();
+  if ( cr != FRAME_CR_CONTEXT(f))
+    {
+      cairo_destroy(cr);
+      FRAME_CR_ACTIVE_CONTEXT(f) = cairo_reference(FRAME_CR_CONTEXT(f));
+
+    }
+  unblock_input();
+}
+
 
 static void evq_enqueue(union buffered_input_event *ev)
 {
@@ -2665,8 +2682,6 @@ pgtk_draw_window_cursor (struct window *w, struct glyph_row *glyph_row, int x,
 	  xic_set_preeditarea (w, x, y);
 #endif
     }
-
-  gtk_widget_queue_draw(FRAME_GTK_WIDGET(f));
 }
 
 static void
@@ -2769,24 +2784,6 @@ pgtk_scroll_run (struct window *w, struct run *run)
 static void
 pgtk_update_begin (struct frame *f)
 {
-  if (! NILP (tip_frame) && XFRAME (tip_frame) == f
-      && ! FRAME_VISIBLE_P (f))
-    return;
-
-  if (! FRAME_CR_SURFACE (f))
-    {
-      int width = FRAME_PIXEL_WIDTH (f);
-      int height = FRAME_PIXEL_HEIGHT (f);
-
-      if (width > 0 && height > 0)
-	{
-	  block_input();
-	  FRAME_CR_SURFACE (f) = cairo_image_surface_create
-	    (CAIRO_FORMAT_ARGB32, width, height);
-	  unblock_input();
-	}
-    }
-
   pgtk_clear_under_internal_border (f);
 }
 
@@ -2949,8 +2946,12 @@ pgtk_update_window_end (struct window *w, bool cursor_on_p,
 static void
 pgtk_update_end (struct frame *f)
 {
+  GtkWidget *widget = FRAME_GTK_WIDGET(f);
   /* Mouse highlight may be displayed again.  */
   MOUSE_HL_INFO (f)->mouse_face_defer = false;
+
+  gtk_widget_queue_draw (widget);
+  flip_cr_context(f);
 }
 
 /* Return the current position of the mouse.
@@ -3123,13 +3124,10 @@ pgtk_cr_draw_image (struct frame *f, Emacs_GC *gc, cairo_pattern_t *image,
 		 int src_x, int src_y, int width, int height,
 		 int dest_x, int dest_y, bool overlay_p)
 {
-  cairo_t *cr;
-  cairo_matrix_t matrix;
-  cairo_surface_t *surface;
-  cairo_format_t format;
+  cairo_t *cr = pgtk_begin_cr_clip (f);
 
   PGTK_TRACE("pgtk_cr_draw_image: 0: %d,%d,%d,%d,%d,%d,%d.", src_x, src_y, width, height, dest_x, dest_y, overlay_p);
-  cr = pgtk_begin_cr_clip (f);
+
   if (overlay_p)
     cairo_rectangle (cr, dest_x, dest_y, width, height);
   else
@@ -3138,42 +3136,24 @@ pgtk_cr_draw_image (struct frame *f, Emacs_GC *gc, cairo_pattern_t *image,
       cairo_rectangle (cr, dest_x, dest_y, width, height);
       cairo_fill_preserve (cr);
     }
-  cairo_clip (cr);
-  cairo_matrix_init_translate (&matrix, src_x - dest_x, src_y - dest_y);
-  cairo_pattern_set_matrix (image, &matrix);
+  cairo_translate (cr, dest_x - src_x, dest_y - src_y);
+
+  cairo_surface_t *surface;
   cairo_pattern_get_surface (image, &surface);
-  format = cairo_image_surface_get_format (surface);
+  cairo_format_t format = cairo_image_surface_get_format (surface);
   if (format != CAIRO_FORMAT_A8 && format != CAIRO_FORMAT_A1)
     {
-      PGTK_TRACE("other format.");
       cairo_set_source (cr, image);
       cairo_fill (cr);
     }
   else
     {
-      if (format == CAIRO_FORMAT_A8)
-	PGTK_TRACE("format A8.");
-      else if (format == CAIRO_FORMAT_A1)
-	PGTK_TRACE("format A1.");
-      else
-	PGTK_TRACE("format ??.");
       pgtk_set_cr_source_with_gc_foreground (f, gc);
-      cairo_rectangle_list_t *rects = cairo_copy_clip_rectangle_list(cr);
-      PGTK_TRACE("rects:");
-      PGTK_TRACE(" status: %u", rects->status);
-      PGTK_TRACE(" rectangles:");
-      for (int i = 0; i < rects->num_rectangles; i++) {
-	PGTK_TRACE("  %fx%f+%f+%f",
-		rects->rectangles[i].width,
-		rects->rectangles[i].height,
-		rects->rectangles[i].x,
-		rects->rectangles[i].y);
-      }
-      cairo_rectangle_list_destroy(rects);
+      cairo_clip (cr);
       cairo_mask (cr, image);
     }
+
   pgtk_end_cr_clip (f);
-  PGTK_TRACE("pgtk_cr_draw_image: 9.");
 }
 
 static void
@@ -3358,8 +3338,6 @@ recover_from_visible_bell(struct atimer *timer)
 
   if (FRAME_X_OUTPUT(f)->atimer_visible_bell != NULL)
     FRAME_X_OUTPUT(f)->atimer_visible_bell = NULL;
-
-  gtk_widget_queue_draw(FRAME_GTK_WIDGET(f));
 }
 
 static void
@@ -3419,8 +3397,6 @@ pgtk_flash (struct frame *f)
 			width, height - 2 * FRAME_INTERNAL_BORDER_WIDTH (f));
 
       FRAME_X_OUTPUT(f)->cr_surface_visible_bell = surface;
-      gtk_widget_queue_draw(FRAME_GTK_WIDGET(f));
-
       {
 	struct timespec delay = make_timespec (0, 50 * 1000 * 1000);
 	if (FRAME_X_OUTPUT(f)->atimer_visible_bell != NULL) {
@@ -4828,12 +4804,12 @@ pgtk_handle_draw(GtkWidget *widget, cairo_t *cr, gpointer *data)
     PGTK_TRACE("  f=%p", f);
     if (f != NULL) {
       src = FRAME_X_OUTPUT(f)->cr_surface_visible_bell;
-      if (src == NULL)
-	src = FRAME_CR_SURFACE(f);
+      if (src == NULL && FRAME_CR_ACTIVE_CONTEXT(f) != NULL)
+	src = cairo_get_target(FRAME_CR_ACTIVE_CONTEXT(f));
     }
-    PGTK_TRACE("  surface=%p", src);
+    APGTK_TRACE("  surface=%p", src);
     if (src != NULL) {
-      PGTK_TRACE("  resized_p=%d", f->resized_p);
+      APGTK_TRACE("  resized_p=%d", f->resized_p);
       PGTK_TRACE("  garbaged=%d", f->garbaged);
       PGTK_TRACE("  scroll_bar_width=%f", (double) PGTK_SCROLL_BAR_WIDTH(f));
       // PGTK_TRACE("  scroll_bar_adjust=%d", PGTK_SCROLL_BAR_ADJUST(f));
@@ -6580,27 +6556,10 @@ pgtk_cr_update_surface_desired_size (struct frame *f, int width, int height)
   if (FRAME_CR_SURFACE_DESIRED_WIDTH (f) != width
       || FRAME_CR_SURFACE_DESIRED_HEIGHT (f) != height)
     {
-      cairo_surface_t *old_surface = FRAME_CR_SURFACE(f);
-      cairo_t *cr = NULL;
-      cairo_t *old_cr = FRAME_CR_CONTEXT(f);
-      FRAME_CR_SURFACE(f) = gdk_window_create_similar_surface(gtk_widget_get_window(FRAME_GTK_WIDGET(f)),
-							      CAIRO_CONTENT_COLOR_ALPHA,
-							      width,
-							      height);
-
-      if (old_surface){
-	cr = cairo_create(FRAME_CR_SURFACE(f));
-	cairo_set_source_surface (cr, old_surface, 0, 0);
-
-	cairo_paint(cr);
-	FRAME_CR_CONTEXT (f) = cr;
-
-        cairo_destroy(old_cr);
-	cairo_surface_destroy (old_surface);
-      }
-      gtk_widget_queue_draw(FRAME_GTK_WIDGET(f));
+      pgtk_cr_destroy_frame_context(f);
       FRAME_CR_SURFACE_DESIRED_WIDTH (f) = width;
       FRAME_CR_SURFACE_DESIRED_HEIGHT (f) = height;
+      SET_FRAME_GARBAGED(f);
     }
 }
 
@@ -6611,16 +6570,17 @@ pgtk_begin_cr_clip (struct frame *f)
   cairo_t *cr = FRAME_CR_CONTEXT (f);
 
   PGTK_TRACE("pgtk_begin_cr_clip");
-  if (! FRAME_CR_SURFACE (f))
-    {
-      FRAME_CR_SURFACE(f) = gdk_window_create_similar_surface(gtk_widget_get_window (FRAME_GTK_WIDGET (f)),
-							      CAIRO_CONTENT_COLOR_ALPHA,
-							      FRAME_PIXEL_WIDTH (f),
-							      FRAME_PIXEL_HEIGHT (f));
-    }
-
   if (!cr)
     {
+      cairo_surface_t *surface =
+	gdk_window_create_similar_surface(gtk_widget_get_window (FRAME_GTK_WIDGET (f)),
+					  CAIRO_CONTENT_COLOR_ALPHA,
+					  FRAME_CR_SURFACE_DESIRED_WIDTH (f),
+					  FRAME_CR_SURFACE_DESIRED_HEIGHT (f));
+
+      cr = FRAME_CR_CONTEXT (f) = cairo_create (surface);
+      cairo_surface_destroy (surface);
+
       cr = cairo_create (FRAME_CR_SURFACE (f));
       FRAME_CR_CONTEXT (f) = cr;
     }
@@ -6635,9 +6595,6 @@ pgtk_end_cr_clip (struct frame *f)
 {
   PGTK_TRACE("pgtk_end_cr_clip");
   cairo_restore (FRAME_CR_CONTEXT (f));
-
-  GtkWidget *widget = FRAME_GTK_WIDGET(f);
-  gtk_widget_queue_draw(widget);
 }
 
 void
@@ -6674,18 +6631,13 @@ pgtk_cr_draw_frame (cairo_t *cr, struct frame *f)
 }
 
 void
-pgtk_cr_destroy_surface(struct frame *f)
+pgtk_cr_destroy_frame_context(struct frame *f)
 {
-  PGTK_TRACE("pgtk_cr_destroy_surface");
+  PGTK_TRACE("pgtk_cr_destroy_frame_context");
   if (FRAME_CR_CONTEXT(f) != NULL) {
     cairo_destroy(FRAME_CR_CONTEXT(f));
     FRAME_CR_CONTEXT(f) = NULL;
   }
-  if (FRAME_CR_SURFACE(f) != NULL) {
-    cairo_surface_destroy(FRAME_CR_SURFACE(f));
-    FRAME_CR_SURFACE(f) = NULL;
-  }
-  SET_FRAME_GARBAGED (f);
 }
 
 void

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -6630,9 +6630,6 @@ pgtk_begin_cr_clip (struct frame *f)
 
       cr = FRAME_CR_CONTEXT (f) = cairo_create (surface);
       cairo_surface_destroy (surface);
-
-      cr = cairo_create (FRAME_CR_SURFACE (f));
-      FRAME_CR_CONTEXT (f) = cr;
     }
 
   cairo_save (cr);

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -700,7 +700,7 @@ x_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_valu
   int width = 0, height = 0;
 
   PGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, width, height );
-  gtk_window_get_size(FRAME_X_WINDOW(f), &width, &height);
+  gtk_window_get_size(FRAME_NATIVE_WINDOW(f), &width, &height);
 
 
   PGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, width, height );
@@ -714,13 +714,14 @@ x_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_valu
       error ("Invalid specification of `parent-frame'");
     }
 
-  if (p != FRAME_PARENT_FRAME (f))
+  if (p != FRAME_PARENT_FRAME (f)
+      && (p != NULL))
     {
       block_input ();
-      gtk_window_set_transient_for(FRAME_X_WINDOW(f), FRAME_X_WINDOW(p));
-      gtk_window_set_attached_to(FRAME_X_WINDOW(f), FRAME_X_WINDOW(p));
-      gtk_window_move(FRAME_X_WINDOW(f), f->left_pos, f->top_pos);
-      gtk_window_set_keep_above(FRAME_X_WINDOW(f), true);
+      gtk_window_set_transient_for(FRAME_NATIVE_WINDOW(f), FRAME_NATIVE_WINDOW(p));
+      gtk_window_set_attached_to(FRAME_NATIVE_WINDOW(f), FRAME_GTK_WIDGET(p));
+      gtk_window_move(FRAME_NATIVE_WINDOW(f), f->left_pos, f->top_pos);
+      gtk_window_set_keep_above(FRAME_NATIVE_WINDOW(f), true);
       //fill this in
       unblock_input ();
 
@@ -2682,8 +2683,6 @@ pgtk_draw_window_cursor (struct window *w, struct glyph_row *glyph_row, int x,
 {
   PGTK_TRACE("draw_window_cursor: %d, %d, %d, %d, %d, %d.",
 	       x, y, cursor_type, cursor_width, on_p, active_p);
-  struct frame *f = XFRAME (WINDOW_FRAME (w));
-  PGTK_TRACE("%p\n", f->output_data.pgtk);
 
   if (on_p)
     {

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -2955,13 +2955,6 @@ pgtk_update_end (struct frame *f)
 {
   /* Mouse highlight may be displayed again.  */
   MOUSE_HL_INFO (f)->mouse_face_defer = false;
-
-  if (FRAME_CR_SURFACE (f))
-    {
-      block_input();
-      gtk_widget_queue_draw(FRAME_GTK_WIDGET(f));
-      unblock_input ();
-    }
 }
 
 /* Return the current position of the mouse.

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -98,7 +98,7 @@ pgtk_any_window_to_frame (GdkWindow *window);
 
 static void flip_cr_context(struct frame *f)
 {
-  APGTK_TRACE("flip_cr_context");
+  PGTK_TRACE("flip_cr_context");
   cairo_t * cr = FRAME_CR_ACTIVE_CONTEXT(f);
 
   block_input();
@@ -407,7 +407,6 @@ pgtk_set_window_size (struct frame *f,
   block_input ();
 
   gtk_widget_get_size_request(FRAME_GTK_WIDGET(f), &pixelwidth, &pixelheight);
-  PGTK_TRACE("old: %dx%d", pixelwidth, pixelheight);
 
   if (pixelwise)
     {
@@ -428,18 +427,13 @@ pgtk_set_window_size (struct frame *f,
 	    make_fixnum (FRAME_PGTK_TITLEBAR_HEIGHT (f)),
 	    make_fixnum (FRAME_TOOLBAR_HEIGHT (f))));
 
-  PGTK_TRACE("new: %dx%d", pixelwidth, pixelheight);
   for (GtkWidget *w = FRAME_GTK_WIDGET(f); w != NULL; w = gtk_widget_get_parent(w)) {
-    PGTK_TRACE("%p %s %d %d", w, G_OBJECT_TYPE_NAME(w), gtk_widget_get_mapped(w), gtk_widget_get_visible(w));
     gint wd, hi;
     gtk_widget_get_size_request(w, &wd, &hi);
-    PGTK_TRACE(" %dx%d", wd, hi);
     GtkAllocation alloc;
     gtk_widget_get_allocation(w, &alloc);
-    PGTK_TRACE(" %dx%d+%d+%d", alloc.width, alloc.height, alloc.x, alloc.y);
   }
 
-  PGTK_TRACE("pgtk_set_window_size: %p: %dx%d.", f, width, height);
   f->output_data.pgtk->preferred_width = pixelwidth;
   f->output_data.pgtk->preferred_height = pixelheight;
   x_wm_set_size_hint(f, 0, 0);
@@ -677,6 +671,63 @@ x_display_pixel_width (struct pgtk_display_info *dpyinfo)
   PGTK_TRACE(" = %d", gdk_screen_get_width(gscr));
   return gdk_screen_get_width(gscr);
 }
+
+void
+x_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+/* --------------------------------------------------------------------------
+     Set frame F's `parent-frame' parameter.  If non-nil, make F a child
+     frame of the frame specified by that parameter.  Technically, this
+     makes F's window-system window a child window of the parent frame's
+     window-system window.  If nil, make F's window-system window a
+     top-level window--a child of its display's root window.
+
+     A child frame's `left' and `top' parameters specify positions
+     relative to the top-left corner of its parent frame's native
+     rectangle.  On macOS moving a parent frame moves all its child
+     frames too, keeping their position relative to the parent
+     unaltered.  When a parent frame is iconified or made invisible, its
+     child frames are made invisible.  When a parent frame is deleted,
+     its child frames are deleted too.
+
+     Whether a child frame has a tool bar may be window-system or window
+     manager dependent.  It's advisable to disable it via the frame
+     parameter settings.
+
+     Some window managers may not honor this parameter.
+   -------------------------------------------------------------------------- */
+{
+  struct frame *p = NULL;
+  int width = 0, height = 0;
+
+  PGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, width, height );
+  gtk_window_get_size(FRAME_X_WINDOW(f), &width, &height);
+
+
+  PGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, width, height );
+
+  if (!NILP (new_value)
+      && (!FRAMEP (new_value)
+	  || !FRAME_LIVE_P (p = XFRAME (new_value))
+	  || !FRAME_PGTK_P (p)))
+    {
+      store_frame_param (f, Qparent_frame, old_value);
+      error ("Invalid specification of `parent-frame'");
+    }
+
+  if (p != FRAME_PARENT_FRAME (f))
+    {
+      block_input ();
+      gtk_window_set_transient_for(FRAME_X_WINDOW(f), FRAME_X_WINDOW(p));
+      gtk_window_set_attached_to(FRAME_X_WINDOW(f), FRAME_X_WINDOW(p));
+      gtk_window_move(FRAME_X_WINDOW(f), f->left_pos, f->top_pos);
+      gtk_window_set_keep_above(FRAME_X_WINDOW(f), true);
+      //fill this in
+      unblock_input ();
+
+      fset_parent_frame (f, new_value);
+    }
+}
+
 
 void
 x_set_no_focus_on_map (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
@@ -4807,9 +4858,9 @@ pgtk_handle_draw(GtkWidget *widget, cairo_t *cr, gpointer *data)
       if (src == NULL && FRAME_CR_ACTIVE_CONTEXT(f) != NULL)
 	src = cairo_get_target(FRAME_CR_ACTIVE_CONTEXT(f));
     }
-    APGTK_TRACE("  surface=%p", src);
+    PGTK_TRACE("  surface=%p", src);
     if (src != NULL) {
-      APGTK_TRACE("  resized_p=%d", f->resized_p);
+      PGTK_TRACE("  resized_p=%d", f->resized_p);
       PGTK_TRACE("  garbaged=%d", f->garbaged);
       PGTK_TRACE("  scroll_bar_width=%f", (double) PGTK_SCROLL_BAR_WIDTH(f));
       // PGTK_TRACE("  scroll_bar_adjust=%d", PGTK_SCROLL_BAR_ADJUST(f));
@@ -6600,7 +6651,7 @@ pgtk_end_cr_clip (struct frame *f)
 void
 pgtk_set_cr_source_with_gc_foreground (struct frame *f, Emacs_GC *gc)
 {
-  PGTK_TRACE("pgtk_set_cr_source_with_gc_foreground: %08lx", gc->foreground);
+  PGTK_TRACE ("pgtk_set_cr_source_with_gc_foreground: %08lx", gc->foreground);
   pgtk_set_cr_source_with_color(f, gc->foreground);
 }
 

--- a/src/pgtkterm.h
+++ b/src/pgtkterm.h
@@ -425,8 +425,8 @@ enum
 
 /* aliases */
 #define FRAME_PGTK_VIEW(f)         FRAME_GTK_WIDGET(f)
-#define FRAME_X_WINDOW(f)          FRAME_GTK_WIDGET(f)
-#define FRAME_NATIVE_WINDOW(f)     FRAME_GTK_WIDGET(f)
+#define FRAME_X_WINDOW(f)          FRAME_GTK_OUTER_WIDGET(f)
+#define FRAME_NATIVE_WINDOW(f)     GTK_WINDOW(FRAME_X_WINDOW(f))
 
 #define FRAME_X_DISPLAY(f)        (FRAME_DISPLAY_INFO(f)->gdpy)
 

--- a/src/pgtkterm.h
+++ b/src/pgtkterm.h
@@ -364,11 +364,10 @@ struct pgtk_output
   int toolbar_left_width, toolbar_right_width;
 
 #ifdef USE_CAIRO
-  /* Cairo drawing context.  */
-  cairo_t *cr_context;
+  /* Cairo drawing contexts.  */
+  cairo_t *cr_context, *cr_active;
   int cr_surface_desired_width, cr_surface_desired_height;
   /* Cairo surface for double buffering */
-  cairo_surface_t *cr_surface;
   cairo_surface_t *cr_surface_visible_bell;
 #endif
   struct atimer *atimer_visible_bell;
@@ -576,7 +575,7 @@ extern void pgtk_set_cr_source_with_gc_foreground (struct frame *f, Emacs_GC *gc
 extern void pgtk_set_cr_source_with_gc_background (struct frame *f, Emacs_GC *gc);
 extern void pgtk_set_cr_source_with_color (struct frame *f, unsigned long color);
 extern void pgtk_cr_draw_frame (cairo_t *cr, struct frame *f);
-extern void pgtk_cr_destroy_surface(struct frame *f);
+extern void pgtk_cr_destroy_frame_context(struct frame *f);
 
 /* Defined in pgtkmenu.c */
 extern Lisp_Object pgtk_popup_dialog (struct frame *f, Lisp_Object header, Lisp_Object contents);


### PR DESCRIPTION
This is an improvement over previous work to reduce flickering.

Rather than delete and recreate a context every render cycle, we swap them once a new context is required.
There are probably some other tweaks that could be made but it's already much better.