### PR TITLE
Pgtk childframe support

### DIFF
--- a/src/ftcrfont.c
+++ b/src/ftcrfont.c
@@ -131,7 +131,9 @@ ftcrfont_open (struct frame *f, Lisp_Object entity, int pixel_size)
   filename = XCAR (val);
   size = XFIXNUM (AREF (entity, FONT_SIZE_INDEX));
   if (size == 0)
+  {
     size = pixel_size;
+  }
 
   block_input ();
 

--- a/src/gtkutil.c
+++ b/src/gtkutil.c
@@ -1350,7 +1350,7 @@ xg_create_frame_widgets (struct frame *f)
   wtop = gtk_window_new (type);
 #ifdef HAVE_PGTK
 	gtk_widget_add_events(wtop, GDK_ALL_EVENTS_MASK);
-	gtk_window_set_hide_titlebar_when_maximized(wtop, TRUE);
+	gtk_window_set_hide_titlebar_when_maximized(GTK_WINDOW(wtop), TRUE);
 #endif
 
   /* gtk_window_set_has_resize_grip is a Gtk+ 3.0 function but Ubuntu
@@ -1693,10 +1693,8 @@ x_wm_set_size_hint (struct frame *f, long int flags, bool user_position)
 		 sizeof (size_hints)) != 0)
     {
       block_input ();
-#ifndef HAVE_PGTK
       gtk_window_set_geometry_hints (GTK_WINDOW (FRAME_GTK_OUTER_WIDGET (f)),
 				     NULL, &size_hints, hint_flags);
-#endif
       f->output_data.xp->size_hints = size_hints;
       f->output_data.xp->hint_flags = hint_flags;
       unblock_input ();

--- a/src/gtkutil.c
+++ b/src/gtkutil.c
@@ -1350,7 +1350,6 @@ xg_create_frame_widgets (struct frame *f)
   wtop = gtk_window_new (type);
 #ifdef HAVE_PGTK
 	gtk_widget_add_events(wtop, GDK_ALL_EVENTS_MASK);
-	gtk_window_set_hide_titlebar_when_maximized(GTK_WINDOW(wtop), TRUE);
 #endif
 
   /* gtk_window_set_has_resize_grip is a Gtk+ 3.0 function but Ubuntu

--- a/src/gtkutil.c
+++ b/src/gtkutil.c
@@ -1326,6 +1326,7 @@ xg_create_frame_widgets (struct frame *f)
 #ifndef HAVE_GTK3
   GtkRcStyle *style;
 #endif
+  GtkWindowType type = GTK_WINDOW_TOPLEVEL;
   char *title = 0;
 
   PGTK_TRACE("xg_create_frame_widgets.");
@@ -1339,9 +1340,17 @@ xg_create_frame_widgets (struct frame *f)
     }
   else
 #endif
-    wtop = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+
 #ifdef HAVE_PGTK
-  gtk_widget_add_events(wtop, GDK_ALL_EVENTS_MASK);
+    if (!NILP(f->parent_frame)){
+      type = GTK_WINDOW_POPUP;
+    }
+#endif
+
+  wtop = gtk_window_new (type);
+#ifdef HAVE_PGTK
+	gtk_widget_add_events(wtop, GDK_ALL_EVENTS_MASK);
+	gtk_window_set_hide_titlebar_when_maximized(wtop, TRUE);
 #endif
 
   /* gtk_window_set_has_resize_grip is a Gtk+ 3.0 function but Ubuntu
@@ -1467,7 +1476,7 @@ xg_create_frame_widgets (struct frame *f)
 #ifndef HAVE_PGTK
   gtk_widget_realize (wfixed);
 #else
-  gtk_widget_show_all(wtop);
+  //  gtk_widget_show_all(wtop);
 #endif
 #ifndef HAVE_PGTK
   FRAME_X_WINDOW (f) = GTK_WIDGET_TO_X_WIN (wfixed);

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -1459,12 +1459,14 @@ This function is an internal primitive--use `make-frame' instead.  */)
       struct frame *p = XFRAME (parent_frame);
 
       block_input ();
-      APGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, -1,-1);
-      gtk_window_set_transient_for(FRAME_GTK_OUTER_WIDGET(f), FRAME_GTK_OUTER_WIDGET(p));
-      gtk_window_set_attached_to(FRAME_GTK_OUTER_WIDGET(f), FRAME_GTK_OUTER_WIDGET(p));
-
+      PGTK_TRACE ("x_set_parent_frame x: %d, y: %d", f->left_pos, f->top_pos);
+      gtk_window_set_transient_for(GTK_WINDOW(FRAME_GTK_OUTER_WIDGET(f)),
+				   GTK_WINDOW(FRAME_GTK_OUTER_WIDGET(p)));
+      gtk_window_set_attached_to(GTK_WINDOW(FRAME_GTK_OUTER_WIDGET(f)),
+				 FRAME_GTK_WIDGET(p));
+      gtk_window_set_destroy_with_parent(GTK_WINDOW(FRAME_GTK_OUTER_WIDGET(f)),
+					 TRUE);
       gtk_widget_show_all(FRAME_GTK_OUTER_WIDGET(f));
-      APGTK_TRACE ("FINISH: x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, -1,-1);
       unblock_input ();
     }
 
@@ -3184,7 +3186,7 @@ void pgtk_log(const char *file, int lineno, const char *fmt, ...)
   va_end(ap);
   fputc('\n', stderr);
 }
-
+#ifdef PGTK_DEBUG
 void pgtk_backtrace(const char *file, int lineno)
 {
   Lisp_Object bt = make_uninit_vector(10);
@@ -3214,7 +3216,7 @@ void pgtk_backtrace(const char *file, int lineno)
 
   fprintf(stderr, "%s %.10s:%04d ********\n", timestr, file, lineno);
 }
-#ifdef PGTK_DEBUG
+
 #endif
 
 #endif

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -3165,7 +3165,7 @@ When using Gtk+ tooltips, the tooltip face is not used.  */);
 }
 
 
-
+#ifdef PGTK_DEBUG
 #include <stdarg.h>
 #include <time.h>
 void pgtk_log(const char *file, int lineno, const char *fmt, ...)
@@ -3186,7 +3186,7 @@ void pgtk_log(const char *file, int lineno, const char *fmt, ...)
   va_end(ap);
   fputc('\n', stderr);
 }
-#ifdef PGTK_DEBUG
+
 void pgtk_backtrace(const char *file, int lineno)
 {
   Lisp_Object bt = make_uninit_vector(10);

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -915,7 +915,7 @@ frame_parm_handler pgtk_frame_parm_handlers[] =
   pgtk_set_tool_bar_position,
   0, /* x_set_inhibit_double_buffering */
   x_set_undecorated,
-  0, /* x_set_parent_frame, */
+  x_set_parent_frame,
   x_set_skip_taskbar,
   x_set_no_focus_on_map,
   x_set_no_accept_focus,
@@ -1454,17 +1454,21 @@ This function is an internal primitive--use `make-frame' instead.  */)
   gui_default_parameter (f, parms, Qalpha, Qnil,
 		       "alpha", "Alpha", RES_TYPE_NUMBER);
 
-#if 0
   if (!NILP (parent_frame))
     {
       struct frame *p = XFRAME (parent_frame);
 
       block_input ();
-      XReparentWindow (FRAME_X_DISPLAY (f), FRAME_OUTER_WINDOW (f),
-		       FRAME_X_WINDOW (p), f->left_pos, f->top_pos);
+      APGTK_TRACE ("x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, -1,-1);
+      gtk_window_set_transient_for(FRAME_GTK_OUTER_WIDGET(f), FRAME_GTK_OUTER_WIDGET(p));
+      gtk_window_set_attached_to(FRAME_GTK_OUTER_WIDGET(f), FRAME_GTK_OUTER_WIDGET(p));
+
+      gtk_widget_show_all(FRAME_GTK_OUTER_WIDGET(f));
+      APGTK_TRACE ("FINISH: x_set_parent_frame x: %d, y: %d, size: %d x %d", f->left_pos, f->top_pos, -1,-1);
       unblock_input ();
     }
-#endif
+
+  gtk_widget_show_all(FRAME_GTK_OUTER_WIDGET(f));
 
   gui_default_parameter (f, parms, Qno_focus_on_map, Qnil,
 		       NULL, NULL, RES_TYPE_BOOLEAN);
@@ -3158,7 +3162,7 @@ When using Gtk+ tooltips, the tooltip face is not used.  */);
   DEFSYM (Qreverse_landscape, "reverse-landscape");
 }
 
-#ifdef PGTK_DEBUG
+
 
 #include <stdarg.h>
 #include <time.h>
@@ -3210,7 +3214,7 @@ void pgtk_backtrace(const char *file, int lineno)
 
   fprintf(stderr, "%s %.10s:%04d ********\n", timestr, file, lineno);
 }
-
+#ifdef PGTK_DEBUG
 #endif
 
 #endif

--- a/src/pgtkmenu.c
+++ b/src/pgtkmenu.c
@@ -458,9 +458,8 @@ DEFUN ("menu-or-popup-active-p", Fmenu_or_popup_active_p, Smenu_or_popup_active_
        doc: /* SKIP: real doc in xmenu.c.  */)
   (void)
 {
-  struct frame *f;
-  f = SELECTED_FRAME ();
-  //  return (f->output_data.pgtk->menubar_active > 0) ? Qt : Qnil;
+  /* struct frame *f = SELECTED_FRAME (); */
+  /* return (f->output_data.pgtk->menubar_active > 0) ? Qt : Qnil; */
   return Qnil;
 }
 

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -818,8 +818,8 @@ pgtk_initialize_display_info (struct pgtk_display_info *dpyinfo)
       Initialize global info and storage for display.
    -------------------------------------------------------------------------- */
 {
-    dpyinfo->resx = 72.27; /* used 75.0, but this makes pt == pixel, expected */
-    dpyinfo->resy = 72.27;
+    dpyinfo->resx = 96;
+    dpyinfo->resy = 96;
     dpyinfo->color_p = 1;
     dpyinfo->n_planes = 32;
     dpyinfo->root_window = 42; /* a placeholder.. */
@@ -5393,7 +5393,7 @@ static gboolean window_state_event(GtkWidget *widget, GdkEvent *event, gpointer 
 
   if (inev.ie.kind != NO_EVENT)
     evq_enqueue(&inev);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean delete_event(GtkWidget *widget, GdkEvent *event, gpointer *user_data)
@@ -6288,7 +6288,13 @@ pgtk_term_init (Lisp_Object display_name, char *resource_name)
 
   {
     GdkScreen *gscr = gdk_display_get_default_screen(dpyinfo->gdpy);
-    gdouble dpi = gdk_screen_get_resolution(gscr);
+
+    GSettings *set = g_settings_new("org.gnome.desktop.interface");
+    gdouble x = g_settings_get_double(set,"text-scaling-factor");
+    gdouble dpi = 0;
+
+    dpi =  96.0 * x;
+    gdk_screen_set_resolution(gscr, dpi);
     dpyinfo->resx = dpi;
     dpyinfo->resy = dpi;
   }

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -357,13 +357,13 @@ x_set_offset (struct frame *f, int xoff, int yoff, int change_gravity)
 {
   /* not working on wayland. */
 
-  PGTK_TRACE("x_set_offset: %d,%d,%d.", xoff, yoff, change_gravity);
+  APGTK_TRACE("x_set_offset: %d,%d,%d.", xoff, yoff, change_gravity);
 
   if (change_gravity > 0)
     {
-      PGTK_TRACE("x_set_offset: change_gravity > 0");
-      f->top_pos = yoff;
-      f->left_pos = xoff;
+      APGTK_TRACE("x_set_offset: change_gravity > 0");
+      f->top_pos = yoff+60;
+      f->left_pos = xoff + 25;
       f->size_hint_flags &= ~ (XNegative | YNegative);
       if (xoff < 0)
 	f->size_hint_flags |= XNegative;
@@ -381,7 +381,7 @@ x_set_offset (struct frame *f, int xoff, int yoff, int change_gravity)
      has been realized already, leave it to gtk_window_move to DTRT
      and return.  Used for Bug#25851 and Bug#25943.  */
   if (change_gravity != 0 && FRAME_GTK_OUTER_WIDGET (f)) {
-    PGTK_TRACE("x_set_offset: move to %d,%d.", f->left_pos, f->top_pos);
+    APGTK_TRACE("x_set_offset: move to %d,%d.", f->left_pos, f->top_pos);
     gtk_window_move (GTK_WINDOW (FRAME_GTK_OUTER_WIDGET (f)),
 		     f->left_pos, f->top_pos);
   }


### PR DESCRIPTION
GTK3 (and 4) use a "popup" window type that can only be set at GtkWindow creation.

This appears to work for X11, Wayland and Broadway, but is a little buggy on Xwayland.

I use this with the `posframe` libraries, mostly `ivy-posframe` and `company-posframe`

