### PR TITLE
Remove re-defined keymaps used for NS/macos ports

### DIFF
--- a/lisp/term/pgtk-win.el
+++ b/lisp/term/pgtk-win.el
@@ -41,17 +41,6 @@
 (defun pgtk-ignore-1-arg (_switch)
   (setq x-invocation-args (cdr x-invocation-args)))
 
-;;;; Keyboard mapping.
-
-(define-obsolete-variable-alias 'pgtk-alternatives-map 'x-alternatives-map "24.1")
-
-(define-key global-map [home] 'beginning-of-buffer)
-(define-key global-map [end] 'end-of-buffer)
-(define-key global-map [kp-home] 'beginning-of-buffer)
-(define-key global-map [kp-end] 'end-of-buffer)
-(define-key global-map [kp-prior] 'scroll-down-command)
-(define-key global-map [kp-next] 'scroll-up-command)
-
 ;;;; File handling.
 
 (defun x-file-dialog (prompt dir default_filename mustmatch only_dir_p)


### PR DESCRIPTION
Clean up a few key-remaps in pgtk-win.el, mostly home, end, PgUp and PgDown

 