### PR TITLE
PGTK Remove references to X'ism Xrdb, aligning with the ns-port

### DIFF
--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -2125,7 +2125,7 @@ pgtk_set_scroll_bar_default_height (struct frame *f)
 
 /* terms impl this instead of x-get-resource directly */
 const char *
-pgtk_get_string_resource (XrmDatabase rdb, const char *name, const char *class)
+pgtk_get_string_resource (void *rdb, const char *name, const char *class)
 {
   check_window_system (NULL);
 

--- a/src/pgtkterm.c
+++ b/src/pgtkterm.c
@@ -159,14 +159,6 @@ mark_pgtkterm(void)
     mark_object (ev->ie.frame_or_window);
     mark_object (ev->ie.arg);
   }
-
-  struct pgtk_display_info *dpyinfo;
-  for (dpyinfo = x_display_list; dpyinfo != NULL; dpyinfo = dpyinfo->next) {
-#if false  /* marked in alloc.c:compact_font_caches() */
-    mark_object (dpyinfo->name_list_element);
-#endif
-    mark_object (dpyinfo->rdb);
-  }
 }
 
 char *

--- a/src/pgtkterm.h
+++ b/src/pgtkterm.h
@@ -164,7 +164,7 @@ struct pgtk_display_info
   Window root_window;
 
   /* Xism */
-  XrmDatabase rdb;
+  Lisp_Object rdb;
 
   /* The cursor to use for vertical scroll bars. */
   Emacs_Cursor vertical_scroll_bar_cursor;
@@ -524,7 +524,7 @@ extern char *pgtk_xlfd_to_fontname (const char *xlfd);
 /* Implemented in pgtkfns. */
 extern void pgtk_set_doc_edited (void);
 extern const char *pgtk_get_defaults_value (const char *key);
-extern const char *pgtk_get_string_resource (XrmDatabase rdb, const char *name, const char *class);
+extern const char *pgtk_get_string_resource (void *rdb, const char *name, const char *class);
 extern void pgtk_implicitly_set_name (struct frame *f, Lisp_Object arg, Lisp_Object oldval);
 
 /* Color management implemented in pgtkterm. */


### PR DESCRIPTION
src/pgtkterm.h: Change rdb to Lisp_Object (remove XrmDatabase), fix signature
src/pgtkterm.c: Do not mark rdb, it's never allocated.
src/pgtkfns.c: Update pgtk_get_string_resource signature