### PR TITLE
Fix crash on creating child frames.

### DIFF
--- a/src/gtkutil.c
+++ b/src/gtkutil.c
@@ -5356,6 +5356,11 @@ update_frame_tool_bar (struct frame *f)
   if (! FRAME_GTK_WIDGET (f))
     return;
 
+#ifdef HAVE_PGTK
+  if (! FRAME_GTK_OUTER_WIDGET (f))
+    return;
+#endif
+
   block_input ();
 
   if (RANGED_FIXNUMP (1, Vtool_bar_button_margin, INT_MAX))

--- a/src/pgtkfns.c
+++ b/src/pgtkfns.c
@@ -3323,6 +3323,8 @@ frame_geometry (Lisp_Object frame, Lisp_Object attribute)
     gtk_window_get_position (GTK_WINDOW (FRAME_GTK_OUTER_WIDGET (f)),
 			     &left_pos, &top_pos);
   } else {
+    if (FRAME_GTK_WIDGET (f) == NULL)
+      return Qnil;    /* This can occur while creating a frame. */
     GtkAllocation alloc;
     gtk_widget_get_allocation (FRAME_GTK_WIDGET (f), &alloc);
     left_pos = alloc.x;


### PR DESCRIPTION
* src/pgtkfns.c (frame_geometry): Returns nil when no widget.