### PR TITLE
Fix mouse cursor doesn't appear on motion events on xwidgets

### DIFF
--- a/src/xwidget.c
+++ b/src/xwidget.c
@@ -510,6 +510,11 @@ xwidget_osr_event_forward (GtkWidget *widget, GdkEvent *event,
      perhaps in xwgir_event_cb.  */
   gtk_main_do_event (eventcopy);
 
+#ifdef HAVE_PGTK
+  /* Pgtk code needs this event */
+  if (event->type == GDK_MOTION_NOTIFY)
+    return FALSE;
+#endif
   /* Don't propagate this event further.  */
   return TRUE;
 }


### PR DESCRIPTION
* src/xwidget.c (xwidget_osr_event_forward): Propagate motion notify.