### PR TITLE
Avoid mutating invocation-name

### DIFF
--- a/lisp/term/pgtk-win.el
+++ b/lisp/term/pgtk-win.el
@@ -303,7 +303,7 @@ See the documentation of `create-fontset-from-fontset-spec' for the format.")
   ;; Make sure we have a valid resource name.
   (or (stringp x-resource-name)
       (let (i)
-	(setq x-resource-name invocation-name)
+	(setq x-resource-name (copy-sequence invocation-name))
 
 	;; Change any . or * characters in x-resource-name to hyphens,
 	;; so as not to choke when we use it in X resource queries.


### PR DESCRIPTION
Using the pgtk build I noticed that any command that tried to launch a new Emacs process using `invocation-name` would fail.

For example with `async-start`:
```
async-start: Process emacs not running
```

I found that `invocation-name` was set to `emacs-28-0-50`, when it should have been set to `emacs-28.0.50`. After a lot of debugging I found that it was being modified in `lisp/term/pgtk-win.el` when it should have been copied like it is in `lisp/term/x-win.el`.

This change just wraps `invocation-name` with `copy-sequence` like in `lisp/term/x-win.el` to avoid mutating the global variable.